### PR TITLE
Specify main as the release branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "format": "web-scripts format",
     "prepublishOnly": "$npm_execpath run build"
   },
+  "release": {
+    "branches": ["main"]
+  },
   "husky": {
     "hooks": {
       "commit-msg": "web-scripts commitmsg",


### PR DESCRIPTION
Semantic release expects a "master" release branch. Since we use main, we need to specify it as a release branch.

[Source](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#branches)